### PR TITLE
chore: remove poetry files from vcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist/
 .env
 .flaskenv
 docker.env
+pyproject.toml
+poetry.lock


### PR DESCRIPTION
### What does this PR do?

- Removes `pyptoject.toml` and `poetry.lock` from vcs.
