### PR TITLE
test: add test to stripe/config endpoint

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,8 @@ from unittest.mock import patch, MagicMock
 
 @pytest.fixture(scope='module')
 def app():
-    app = create_app('testing')    
+    app = create_app('testing') 
+    app.config['STRIPE_PUBLISHABLE_KEY'] = 'test_public_key'   
     with app.app_context():
         db.create_all()
         yield app

--- a/tests/unit/test_stripe.py
+++ b/tests/unit/test_stripe.py
@@ -1,0 +1,6 @@
+def test_config(client):
+    response = client.get('/stripe/config')
+    assert response.status_code == 200
+    response_data = response.get_json()
+    assert response_data == {"public_key": 'test_public_key'}
+


### PR DESCRIPTION
### What does this PR do?

- Adds `test_config` to test the `stripe/config` endpoint.

### Related Issue(s)?

- Resolves #20 