### PR TITLE
test: add test to stripe/create-checkout-session endpoint

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ from unittest.mock import patch, MagicMock
 def app():
     app = create_app('testing') 
     app.config['STRIPE_PUBLISHABLE_KEY'] = 'test_public_key'   
+    app.config['BASE_URL'] = 'http://localhost/'
+    app.config['STRIPE_SECRET_KEY'] = 'test_secret_key'
     with app.app_context():
         db.create_all()
         yield app
@@ -48,3 +50,20 @@ def mock_create_product():
     with patch("stripe.Product.create", return_value=mock_product):
         yield mock_product
 
+@pytest.fixture
+def mock_create_checkout_session():
+    mock_response = {
+        'id': 'test_session_id',
+        'line_items': [
+            {
+                'price': 'price_test_id',
+                'quantity': 1
+            }
+        ],
+        'success_url': 'http://localhost/success?session_id=test_session_id',
+        'cancel_url': 'http://localhost/cancelled',
+        'payment_method_types': ['card'],
+        'mode': 'payment'
+    }
+    with patch('stripe.checkout.Session.create', return_value=mock_response):
+        yield mock_response

--- a/tests/unit/test_stripe.py
+++ b/tests/unit/test_stripe.py
@@ -1,6 +1,26 @@
+import pytest
+
 def test_config(client):
     response = client.get('/stripe/config')
     assert response.status_code == 200
     response_data = response.get_json()
     assert response_data == {"public_key": 'test_public_key'}
 
+def test_create_checkout(client, mock_create_checkout_session):
+    payload = {
+            'price_id': 'price_test_id'
+        }
+    response = client.post(
+        '/stripe/create-checkout-session',
+        json=payload
+    )
+    import pdb; pdb.set_trace()
+    assert response.status_code == 200
+    response_data = response.get_json()
+    assert response_data == {'sessionId' : 'test_session_id'}
+    assert 'price' in mock_create_checkout_session['line_items'][0]
+    assert mock_create_checkout_session['payment_method_types'] == ['card']
+    assert mock_create_checkout_session['mode'] == 'payment'
+    assert mock_create_checkout_session['line_items'][0]['price'] == 'price_test_id'
+    assert mock_create_checkout_session['success_url'] == 'http://localhost/success?session_id=test_session_id'  
+    


### PR DESCRIPTION
### What does this PR do?
- Add fixture to mock creation of checkout session
- Write corresponding test utilizing the fixture

### Related issue(s)?

- Resolves #20 