### PR TITLE
ci: add deploy job to ci/cd workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,20 @@ jobs:
         if: always()
         run: |
           docker compose down
+  
+  deploy:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        run: echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+
+      - name: Tag and push Docker image
+      run: |
+        docker tag my-fastapi-app ${{ secrets.DOCKER_HUB_USERNAME }}/my-fastapi-app:latest
+        docker push ${{ secrets.DOCKER_HUB_USERNAME }}/my-fastapi-app:latest


### PR DESCRIPTION
### What does this PR do?
- Adds deploy job to ci workflow to deploy latest application image to docker hub.

### Related issue(s)?
- Resolves #43 